### PR TITLE
Fixed build by finalizing removal of SeedMyThings from EFDataLayer assembly

### DIFF
--- a/PrivateConstructorSettersAndEF/EFDataLayer/EFDataLayer.csproj
+++ b/PrivateConstructorSettersAndEF/EFDataLayer/EFDataLayer.csproj
@@ -44,7 +44,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="SeedMyThings.cs" />
     <Compile Include="ThingieContext.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/PrivateConstructorSettersAndEF/TestProject/Tests.cs
+++ b/PrivateConstructorSettersAndEF/TestProject/Tests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using EFDataLayer;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PrivateConstructorSettersAndEF;
+using IntegrationTestHelpers;
 
 namespace TestProject
 {


### PR DESCRIPTION
There was a reference to the removed `SeedMyThings.cs` file in the `.csproj`.

The use of `SeedMyThings` in the tests project was missing a using statement.
